### PR TITLE
Initialize tm struct in debug logger

### DIFF
--- a/Plugins/uWindowCapture/uWindowCapture/Debug.h
+++ b/Plugins/uWindowCapture/uWindowCapture/Debug.h
@@ -103,7 +103,7 @@ private:
     static void OutputTime()
     {
         auto t = time(nullptr);
-        tm tm;
+        tm tm{};
         localtime_s(&tm, &t);
         char buf[64];
         strftime(buf, 64, "%F %T", &tm);


### PR DESCRIPTION
## Summary
- initialize `tm` in debug timestamp generation to avoid reading uninitialized memory

## Testing
- `cppcheck --enable=performance --std=c++17 --language=c++ --inconclusive Plugins/uWindowCapture/uWindowCapture && echo 'cppcheck ok'`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f667eeb883329c84f26fe4b0d611