### PR TITLE
Fix desktop removal events and reuse fallback icon texture

### DIFF
--- a/Assets/uWindowCapture/Runtime/UwcManager.cs
+++ b/Assets/uWindowCapture/Runtime/UwcManager.cs
@@ -211,12 +211,13 @@ public class UwcManager : MonoBehaviour
                 case MessageType.WindowRemoved: {
                     var window = Find(id);
                     if (window != null) {
+                        var wasDesktop = window.isDesktop;
                         window.isAlive = false;
                         if (window.parentWindow != null) {
                             window.parentWindow.onChildRemoved.Invoke(window);
                         }
                         windows.Remove(id);
-                        if (window.isAlive && window.isDesktop) {
+                        if (wasDesktop) {
                             desktops_.Remove(id);
                             onDesktopRemoved.Invoke(window);
                         } else {

--- a/Assets/uWindowCapture/Runtime/UwcWindow.cs
+++ b/Assets/uWindowCapture/Runtime/UwcWindow.cs
@@ -244,6 +244,8 @@ public class UwcWindow
         private set;
     }
 
+    private static Texture2D defaultErrorIconTexture_;
+    private static bool loggedMissingDefaultIcon_ = false;
     private Texture2D iconTexture_;
     private Texture2D errorIconTexture_;
     private bool hasIconTextureCaptured_ = false;
@@ -387,7 +389,19 @@ public class UwcWindow
         iconTexture_.filterMode = FilterMode.Bilinear;
         iconTexture_.wrapMode = TextureWrapMode.Clamp;
         Lib.SetWindowIconTexturePtr(id, iconTexture_.GetNativeTexturePtr());
-        errorIconTexture_ = Resources.Load<Texture2D>("uWindowCapture/Textures/uWC_No_Image");
+        errorIconTexture_ = GetDefaultErrorIconTexture();
+    }
+
+    private static Texture2D GetDefaultErrorIconTexture()
+    {
+        if (!defaultErrorIconTexture_) {
+            defaultErrorIconTexture_ = Resources.Load<Texture2D>("uWindowCapture/Textures/uWC_No_Image");
+            if (!defaultErrorIconTexture_ && !loggedMissingDefaultIcon_) {
+                Debug.LogWarning("uWindowCapture: Failed to load fallback icon texture at Resources/uWindowCapture/Textures/uWC_No_Image.");
+                loggedMissingDefaultIcon_ = true;
+            }
+        }
+        return defaultErrorIconTexture_;
     }
 
     public Color32[] GetPixels(int x, int y, int width, int height)

--- a/Assets/uWindowCapture/Runtime/UwcWindowTexture.cs
+++ b/Assets/uWindowCapture/Runtime/UwcWindowTexture.cs
@@ -257,6 +257,10 @@ public class UwcWindowTexture : MonoBehaviour
         if (!isValid) {
             material_.mainTexture = null;
             hasLastCursorDrawValue_ = false;
+            if (searchAnotherWindowWhenInvalid) {
+                shouldUpdateWindow = true;
+            }
+            UpdateBasicComponents();
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure desktop removal events fire when a desktop window is destroyed so the manager’s desktop list stays in sync
- let window textures rescan when their target becomes invalid and immediately disable render/collider state while invalid
- cache the fallback icon texture so it is only loaded once and warn once if the asset is missing

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d3d9110dc483328e44b90d03b54436