### PR TITLE
Optimize window data ordering

### DIFF
--- a/Plugins/uWindowCapture/uWindowCapture/WindowManager.cpp
+++ b/Plugins/uWindowCapture/uWindowCapture/WindowManager.cpp
@@ -414,14 +414,12 @@ void WindowManager::UpdateWindowHandleList()
         OutputApiError(__FUNCTION__, "EnumDisplayMonitors");
     }
 
-    std::sort(
-        windowDataList_[1].begin(), 
-        windowDataList_[1].end(), 
-        [](const auto& a, const auto& b) 
+    std::stable_partition(
+        windowDataList_[1].begin(),
+        windowDataList_[1].end(),
+        [](const auto& data)
         {
-            return 
-                a.hOwner == nullptr &&
-                b.hOwner != nullptr;
+            return data.hOwner == nullptr;
         });
 
     {


### PR DESCRIPTION
## Summary
- replace the window list std::sort with std::stable_partition to group ownerless windows first
- avoid the O(n log n) reorder cost on every window enumeration pass while keeping relative order of entries

## Testing
- not run (native plugin code)

------
https://chatgpt.com/codex/tasks/task_e_68d3fb0402e0833299e2ca7fccd6f445