### PR TITLE
Fix capture rate edge cases and prevent material leaks

### DIFF
--- a/Assets/uWindowCapture/Runtime/UwcCursorTexture.cs
+++ b/Assets/uWindowCapture/Runtime/UwcCursorTexture.cs
@@ -4,32 +4,55 @@ namespace uWindowCapture
 {
 
 [RequireComponent(typeof(Renderer))]
-public class UwcCursorTexture : MonoBehaviour 
+public class UwcCursorTexture : MonoBehaviour
 {
     Renderer renderer_;
     Material material_;
-
-    UwcCursor cursor
-    {
-        get { return UwcManager.cursor; }
-    }
+    UwcCursor cursor_;
 
     void Awake()
     {
         renderer_ = GetComponent<Renderer>();
         material_ = renderer_.material; // clone
-        cursor.onTextureChanged.AddListener(OnTextureChanged);
+        cursor_ = UwcManager.cursor;
+        if (cursor_ != null) {
+            cursor_.onTextureChanged.AddListener(OnTextureChanged);
+        }
     }
 
     void Update()
     {
-        cursor.CreateTextureIfNeeded();
-        cursor.RequestCapture();
+        if (cursor_ == null) {
+            return;
+        }
+
+        cursor_.CreateTextureIfNeeded();
+        cursor_.RequestCapture();
     }
 
     void OnTextureChanged()
     {
-        material_.mainTexture = cursor.texture;
+        if (cursor_ == null) {
+            return;
+        }
+
+        material_.mainTexture = cursor_.texture;
+    }
+
+    void OnDestroy()
+    {
+        if (cursor_ != null) {
+            cursor_.onTextureChanged.RemoveListener(OnTextureChanged);
+        }
+
+        if (material_) {
+            if (Application.isPlaying) {
+                Destroy(material_);
+            } else {
+                DestroyImmediate(material_);
+            }
+            material_ = null;
+        }
     }
 }
 

--- a/Assets/uWindowCapture/Runtime/UwcIconTexture.cs
+++ b/Assets/uWindowCapture/Runtime/UwcIconTexture.cs
@@ -7,6 +7,8 @@ namespace uWindowCapture
 public class UwcIconTexture : MonoBehaviour
 {
     [SerializeField] UwcWindowTexture windowTexture_;
+    Renderer renderer_;
+    Material material_;
     public UwcWindowTexture windowTexture
     {
         get
@@ -31,6 +33,14 @@ public class UwcIconTexture : MonoBehaviour
         }
         set
         {
+            if (window_ == value) {
+                return;
+            }
+
+            if (window_ != null) {
+                window_.onIconCaptured.RemoveListener(OnIconCaptured);
+            }
+
             window_ = value;
 
             if (window_ != null) {
@@ -52,6 +62,12 @@ public class UwcIconTexture : MonoBehaviour
         }
     }
 
+    void Awake()
+    {
+        renderer_ = GetComponent<Renderer>();
+        material_ = renderer_.material; // clone
+    }
+
     void Update()
     {
         if (windowTexture != null) {
@@ -65,9 +81,24 @@ public class UwcIconTexture : MonoBehaviour
     {
         if (!isValid) return;
 
-        var renderer = GetComponent<Renderer>();
-        renderer.material.mainTexture = window.iconTexture;
+        material_.mainTexture = window.iconTexture;
         window.onIconCaptured.RemoveListener(OnIconCaptured);
+    }
+
+    void OnDestroy()
+    {
+        if (window_ != null) {
+            window_.onIconCaptured.RemoveListener(OnIconCaptured);
+        }
+
+        if (material_) {
+            if (Application.isPlaying) {
+                Destroy(material_);
+            } else {
+                DestroyImmediate(material_);
+            }
+            material_ = null;
+        }
     }
 }
 

--- a/Assets/uWindowCapture/Runtime/UwcWindowTexture.cs
+++ b/Assets/uWindowCapture/Runtime/UwcWindowTexture.cs
@@ -251,6 +251,19 @@ public class UwcWindowTexture : MonoBehaviour
 
     void OnDestroy()
     {
+        if (window_ != null) {
+            window_.onCaptured.RemoveListener(OnCaptured);
+        }
+
+        if (material_) {
+            if (Application.isPlaying) {
+                Destroy(material_);
+            } else {
+                DestroyImmediate(material_);
+            }
+            material_ = null;
+        }
+
         list_.Remove(this);
     }
 
@@ -380,15 +393,24 @@ public class UwcWindowTexture : MonoBehaviour
         if (captureFrameRate < 0) {
             captureTimer_ = 0f;
             isCaptureRequested_ = true;
-        } else { 
-            captureTimer_ += Time.deltaTime;
+            return;
+        }
 
-            float T = 1f / captureFrameRate;
-            if (captureTimer_ < T) return;
+        if (captureFrameRate == 0) {
+            captureTimer_ = 0f;
+            isCaptureRequested_ = false;
+            return;
+        }
 
-            while (captureTimer_  > T) {
-                captureTimer_ -= T;
-            }
+        captureTimer_ += Time.deltaTime;
+
+        float T = 1f / captureFrameRate;
+        if (captureTimer_ < T) {
+            return;
+        }
+
+        while (captureTimer_ > T) {
+            captureTimer_ -= T;
         }
 
         isCaptureRequested_ = true;


### PR DESCRIPTION
## Summary
- guard the capture timer against zero frame rate inputs and clean up listeners when window textures are destroyed
- release cloned materials and event subscriptions for cursor and icon textures to avoid leaks and null reference issues
- reuse cached renderer materials instead of repeatedly instantiating them when updating icon textures

## Testing
- not run (Unity project without automated tests in container)


------
https://chatgpt.com/codex/tasks/task_e_68d448df29a08332bc02ae8268f24085