### PR TITLE
Add converter unit tests and run them in release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,14 @@ jobs:
           # Fetches all history, which is needed for the UPM branch action
           fetch-depth: 0
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Run unit tests
+        run: dotnet test Tests/uWindowCapture.Tests/uWindowCapture.Tests.csproj --configuration Release
+
       # Step 2: Determine the version number from the trigger (tag or manual input)
       - name: Get Version
         id: get_version

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /[Ll]ibrary/
 /[Tt]emp/
 /[Oo]bj/
+**/[Bb]in/
+**/[Oo]bj/
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
@@ -34,6 +36,7 @@
 ExportedObj/
 .consulo/
 *.csproj
+!Tests/**/*.csproj
 *.unityproj
 *.sln
 *.suo

--- a/Assets/uWindowCapture/Runtime/DesktopCoordinateConverter.cs
+++ b/Assets/uWindowCapture/Runtime/DesktopCoordinateConverter.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace uWindowCapture
+{
+    internal readonly struct DesktopScreenMetrics
+    {
+        public DesktopScreenMetrics(int x, int y, int width, int height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public int X { get; }
+        public int Y { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public int CenterX => X + Width / 2;
+        public int CenterY => Y + Height / 2;
+    }
+
+    internal readonly struct DesktopWindowRectangle
+    {
+        public DesktopWindowRectangle(int x, int y, int width, int height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public int X { get; }
+        public int Y { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public int CenterX => X + Width / 2;
+        public int CenterY => Y + Height / 2;
+    }
+
+    internal readonly struct UnityDesktopCoordinates
+    {
+        public UnityDesktopCoordinates(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public float X { get; }
+        public float Y { get; }
+    }
+
+    internal static class DesktopCoordinateConverter
+    {
+        public static UnityDesktopCoordinates ConvertToUnityCoordinates(
+            DesktopWindowRectangle window,
+            DesktopScreenMetrics screen,
+            float basePixel)
+        {
+            if (Math.Abs(basePixel) < float.Epsilon)
+            {
+                throw new ArgumentException("basePixel must not be zero.", nameof(basePixel));
+            }
+
+            var unityX = (window.CenterX - screen.CenterX) / basePixel;
+            var unityY = (-window.CenterY + screen.CenterY) / basePixel;
+            return new UnityDesktopCoordinates(unityX, unityY);
+        }
+    }
+}

--- a/Assets/uWindowCapture/Runtime/UwcWindowUtil.cs
+++ b/Assets/uWindowCapture/Runtime/UwcWindowUtil.cs
@@ -7,23 +7,15 @@ public static class UwcWindowUtil
 {
     public static Vector3 ConvertDesktopCoordToUnityPosition(int x, int y, int width, int height, float basePixel)
     {
-        var w = width;
-        var h = height;
-        var l = x;
-        var t = y;
-        var cx = l + w / 2;
-        var cy = t + h / 2;
+        var screenMetrics = new DesktopScreenMetrics(
+            Lib.GetScreenX(),
+            Lib.GetScreenY(),
+            Lib.GetScreenWidth(),
+            Lib.GetScreenHeight());
 
-        var sw = Lib.GetScreenWidth();
-        var sh = Lib.GetScreenHeight();
-        var sl = Lib.GetScreenX();
-        var st = Lib.GetScreenY();
-        var sCX = sl + sw / 2;
-        var sCY = st + sh / 2;
-
-        var unityX = (cx - sCX) / basePixel;
-        var unityY = (-cy + sCY) / basePixel;
-        return new Vector3(unityX, unityY, 0f);
+        var windowRectangle = new DesktopWindowRectangle(x, y, width, height);
+        var unityCoords = DesktopCoordinateConverter.ConvertToUnityCoordinates(windowRectangle, screenMetrics, basePixel);
+        return new Vector3(unityCoords.X, unityCoords.Y, 0f);
     }
 
     public static Vector3 ConvertDesktopCoordToUnityPosition(UwcWindow window, float basePixel)

--- a/Tests/uWindowCapture.Tests/DesktopCoordinateConverterTests.cs
+++ b/Tests/uWindowCapture.Tests/DesktopCoordinateConverterTests.cs
@@ -1,0 +1,77 @@
+using NUnit.Framework;
+
+namespace uWindowCapture.Tests;
+
+public class DesktopCoordinateConverterTests
+{
+    [Test]
+    public void ConvertToUnityCoordinates_WindowCenteredOnScreen_ReturnsOrigin()
+    {
+        var window = new DesktopWindowRectangle(0, 0, 1920, 1080);
+        var screen = new DesktopScreenMetrics(0, 0, 1920, 1080);
+
+        var result = DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 1f);
+
+        Assert.That(result.X, Is.EqualTo(0f));
+        Assert.That(result.Y, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_WindowOffsetOnSameScreen_ReturnsTranslatedCoordinates()
+    {
+        var window = new DesktopWindowRectangle(960, -540, 1920, 1080);
+        var screen = new DesktopScreenMetrics(0, 0, 1920, 1080);
+
+        var result = DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 1f);
+
+        Assert.That(result.X, Is.EqualTo(960f));
+        Assert.That(result.Y, Is.EqualTo(540f));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_WindowOnSecondaryMonitor_AccountsForScreenOffset()
+    {
+        var window = new DesktopWindowRectangle(-1920, 0, 1920, 1080);
+        var screen = new DesktopScreenMetrics(-1920, 0, 1920, 1080);
+
+        var result = DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 1f);
+
+        Assert.That(result.X, Is.EqualTo(0f));
+        Assert.That(result.Y, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_UsesBasePixelToScaleCoordinates()
+    {
+        var window = new DesktopWindowRectangle(0, 0, 1920, 1080);
+        var screen = new DesktopScreenMetrics(0, 0, 3840, 2160);
+
+        var result = DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 2f);
+
+        Assert.That(result.X, Is.EqualTo(-480f));
+        Assert.That(result.Y, Is.EqualTo(270f));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_OddSizedWindowMatchesIntegerDivisionBehaviour()
+    {
+        var window = new DesktopWindowRectangle(5, 5, 3, 3);
+        var screen = new DesktopScreenMetrics(0, 0, 10, 10);
+
+        var result = DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 1f);
+
+        Assert.That(result.X, Is.EqualTo(1f));
+        Assert.That(result.Y, Is.EqualTo(-1f));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_ZeroBasePixel_ThrowsArgumentException()
+    {
+        var window = new DesktopWindowRectangle(0, 0, 100, 100);
+        var screen = new DesktopScreenMetrics(0, 0, 200, 200);
+
+        Assert.That(
+            () => DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 0f),
+            Throws.ArgumentException.With.Message.Contains("basePixel"));
+    }
+}

--- a/Tests/uWindowCapture.Tests/uWindowCapture.Tests.csproj
+++ b/Tests/uWindowCapture.Tests/uWindowCapture.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Assets/uWindowCapture/Runtime/DesktopCoordinateConverter.cs" Link="Runtime/DesktopCoordinateConverter.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- factor the desktop coordinate conversion math into a dedicated helper that validates the input
- add an NUnit-based test project that exercises several desktop/window layout scenarios
- run the unit tests as part of the release workflow so regressions are caught before publishing

## Testing
- dotnet test Tests/uWindowCapture.Tests/uWindowCapture.Tests.csproj


------
https://chatgpt.com/codex/tasks/task_e_68d4dc42c73883328260479ae16f237f