### PR TITLE
Validate base pixel input

### DIFF
--- a/Assets/uWindowCapture/Runtime/DesktopCoordinateConverter.cs
+++ b/Assets/uWindowCapture/Runtime/DesktopCoordinateConverter.cs
@@ -59,9 +59,20 @@ namespace uWindowCapture
             DesktopScreenMetrics screen,
             float basePixel)
         {
-            if (Math.Abs(basePixel) < float.Epsilon)
+            if (!float.IsFinite(basePixel))
             {
-                throw new ArgumentException("basePixel must not be zero.", nameof(basePixel));
+                throw new ArgumentOutOfRangeException(
+                    nameof(basePixel),
+                    basePixel,
+                    "basePixel must be a finite, positive value.");
+            }
+
+            if (basePixel <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(basePixel),
+                    basePixel,
+                    "basePixel must be a finite, positive value.");
             }
 
             var unityX = (window.CenterX - screen.CenterX) / basePixel;

--- a/Tests/uWindowCapture.Tests/DesktopCoordinateConverterTests.cs
+++ b/Tests/uWindowCapture.Tests/DesktopCoordinateConverterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace uWindowCapture.Tests;
@@ -65,13 +66,35 @@ public class DesktopCoordinateConverterTests
     }
 
     [Test]
-    public void ConvertToUnityCoordinates_ZeroBasePixel_ThrowsArgumentException()
+    public void ConvertToUnityCoordinates_ZeroBasePixel_ThrowsArgumentOutOfRangeException()
     {
         var window = new DesktopWindowRectangle(0, 0, 100, 100);
         var screen = new DesktopScreenMetrics(0, 0, 200, 200);
 
         Assert.That(
             () => DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, 0f),
-            Throws.ArgumentException.With.Message.Contains("basePixel"));
+            Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("basePixel"));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_NegativeBasePixel_ThrowsArgumentOutOfRangeException()
+    {
+        var window = new DesktopWindowRectangle(0, 0, 100, 100);
+        var screen = new DesktopScreenMetrics(0, 0, 200, 200);
+
+        Assert.That(
+            () => DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, -1f),
+            Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("basePixel"));
+    }
+
+    [Test]
+    public void ConvertToUnityCoordinates_NonFiniteBasePixel_ThrowsArgumentOutOfRangeException()
+    {
+        var window = new DesktopWindowRectangle(0, 0, 100, 100);
+        var screen = new DesktopScreenMetrics(0, 0, 200, 200);
+
+        Assert.That(
+            () => DesktopCoordinateConverter.ConvertToUnityCoordinates(window, screen, float.PositiveInfinity),
+            Throws.InstanceOf<ArgumentOutOfRangeException>().With.Message.Contains("basePixel"));
     }
 }


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite base pixel values before converting desktop coordinates
- expand the DesktopCoordinateConverter unit test suite to cover the new validation scenarios

## Testing
- dotnet test Tests/uWindowCapture.Tests/uWindowCapture.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d4e97c17248332b44e2c4a7c6519fb